### PR TITLE
Release/1.0.3

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -18,7 +18,7 @@
 ### Gradle 설정
 ``` gradle
 dependencies {
-  implementation 'io.github.hangyeolee:androidpdfwriter:1.0.2'
+  implementation 'io.github.hangyeolee:androidpdfwriter:1.0.3'
 }
 ```
 
@@ -27,7 +27,7 @@ dependencies {
 <dependency>
     <groupId>io.github.hangyeolee</groupId>
     <artifactId>androidpdfwriter</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A easy to create PDF file library for Android.
 ### Gradle Setup
 ``` gradle
 dependencies {
-  implementation 'io.github.hangyeolee:androidpdfwriter:1.0.2'
+  implementation 'io.github.hangyeolee:androidpdfwriter:1.0.3'
 }
 ```
 
@@ -27,7 +27,7 @@ dependencies {
 <dependency>
     <groupId>io.github.hangyeolee</groupId>
     <artifactId>androidpdfwriter</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 </dependency>
 ```
 

--- a/android-pdf-writer/build.gradle
+++ b/android-pdf-writer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 ext {
     PUBLISH_GROUP_ID = 'io.github.hangyeolee'
-    PUBLISH_VERSION = '1.0.2'
+    PUBLISH_VERSION = '1.0.3'
     PUBLISH_ARTIFACT_ID = 'androidpdfwriter'
     PUBLISH_DESCRIPTION = 'A easy to create PDF file library for Android.'
     PUBLISH_URL = 'https://github.com/hangyeolee/AndroidPdfWriter'

--- a/android-pdf-writer/src/androidTest/java/com/hangyeolee/androidpdfwriter/PDFBuilderTest.java
+++ b/android-pdf-writer/src/androidTest/java/com/hangyeolee/androidpdfwriter/PDFBuilderTest.java
@@ -1,5 +1,6 @@
 package com.hangyeolee.androidpdfwriter;
 
+import android.Manifest;
 import android.content.Context;
 import android.graphics.Color;
 import android.net.Uri;
@@ -7,6 +8,7 @@ import android.os.Environment;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.GrantPermissionRule;
 
 import com.hangyeolee.androidpdfwriter.components.PDFH1;
 import com.hangyeolee.androidpdfwriter.components.PDFH3;
@@ -18,6 +20,7 @@ import com.hangyeolee.androidpdfwriter.utils.StandardDirectory;
 import com.hangyeolee.androidpdfwriter.utils.TextAlign;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -25,6 +28,9 @@ import org.junit.runner.RunWith;
 public class PDFBuilderTest {
     Context context;
     PDFBuilder<PDFLinearLayout> builder;
+
+    @Rule
+    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
 
     @Before
     public void setUp(){

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/PDFBuilder.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/PDFBuilder.java
@@ -114,7 +114,7 @@ public class PDFBuilder<T extends PDFLayout> {
      * @param ratio 0.1f ~ 100.0f, default = 5.0f
      */
     public PDFBuilder<T> setDPI(@FloatRange(from = 0.1f, to = 100.0f) float ratio){
-        Zoomable.getInstance().density = 72.0f * ratio;
+        Zoomable.getInstance().density = ratio;
         return this;
     }
 
@@ -177,7 +177,7 @@ public class PDFBuilder<T extends PDFLayout> {
 
                 uri = context.getContentResolver().insert(
                         MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL)
-                        ,values);
+                        , values);
                 if(uri == null) throw new NullPointerException("Can not Create PDF file at " + relativePath);
                 fos = context.getContentResolver().openOutputStream(uri, "w");
             } else {
@@ -187,13 +187,10 @@ public class PDFBuilder<T extends PDFLayout> {
 
                 if(!StandardDirectory.isStandardDirectory(relativePath)){
                     dir = new File(relativePath);
-                    dir.mkdirs();
+                    if(!dir.mkdirs())
+                        throw new NullPointerException("Can not Make Directory : " + relativePath);
                 }else{
-                    if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M){
-                        dir = context.getExternalFilesDir(relativePath);
-                    } else {
-                        dir = Environment.getExternalStoragePublicDirectory(relativePath);
-                    }
+                    dir = Environment.getExternalStoragePublicDirectory(relativePath);
                 }
 
                 file = new File(dir, filename);


### PR DESCRIPTION
PDF 파일 저장 관련 API 별 문제 해결
현재 테스트 된 API 버전은 API 26 ~ 33 이다.
이는 전체 기기의 94.9% 이다.

Troubleshooting API specific issues with PDF file storage
API versions currently tested are API 26 ~ 33.
This is 94.9% of all devices.