### PR TITLE
Hotfix/v1.1.0

### DIFF
--- a/android-pdf-writer/build.gradle
+++ b/android-pdf-writer/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 ext {
     PUBLISH_GROUP_ID = 'io.github.hangyeolee'
-    PUBLISH_VERSION = '1.1.0'
+    PUBLISH_VERSION = '1.1.1'
     PUBLISH_ARTIFACT_ID = 'androidpdfwriter'
     PUBLISH_DESCRIPTION = 'Easy PDF Library for Android.'
     PUBLISH_URL = 'https://github.com/hangyeolee/AndroidPdfWriter'

--- a/android-pdf-writer/build.gradle
+++ b/android-pdf-writer/build.gradle
@@ -32,7 +32,7 @@ android {
         namespace "com.hangyeolee.androidpdfwriter"
         minSdkVersion 14
         targetSdk 34
-        versionCode 4
+        versionCode 5
         versionName PUBLISH_VERSION
 
         testApplicationId "com.hangyeolee.androidpdfwriter.test"

--- a/android-pdf-writer/src/androidTest/java/com/hangyeolee/androidpdfwriter/PDFTableTest.java
+++ b/android-pdf-writer/src/androidTest/java/com/hangyeolee/androidpdfwriter/PDFTableTest.java
@@ -30,6 +30,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.InputStream;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Formatter;
+import java.util.Locale;
 
 @RunWith(AndroidJUnit4.class)
 public class PDFTableTest {
@@ -279,5 +283,52 @@ public class PDFTableTest {
         }
         builder.draw();
         builder.save(context, StandardDirectory.DIRECTORY_DOWNLOADS, "test_GridLayout_korea.pdf");
+    }
+
+    final int TITLE = 26;                   //제목
+    final int SUB_TITLE = 18;               //부제목
+    final int ANIMAL_INFORMATION = 14;      //동물 정보
+    final int SUBJECT = 16;                 //주제
+    final int CONTENTS = 12;                //내용
+    final int TABLE_CHART = 10;             //표
+    final int PARAGRAPH = 8;                //워드 단락 나누기 포인트 설정값.
+    final float SPACING = 1.08f;            //줄간격 = 폰트 사이즈 *1.08 => 워드 설정값.
+    @Test
+    public void testReport() {
+        PDFBuilder builder = new PDFBuilder(Paper.A4).setPagePadding(36, 36).setQuality(70);
+        {
+            builder.root = PDFLinearLayout.build(Orientation.Vertical)
+                    .addChild(PDFEmpty.build()
+                            .setPadding(0, (int) convertWordPointToPixel(22 * (1 + SPACING) * 6), 0, 0) )
+                    .addChild(PDFLinearLayout.build(Orientation.Vertical)
+                            .addChild(PDFImage.fromResource(context, com.hangyeolee.pdf.core.test.R.drawable.test)     //(폰트사이즈 22 + 줄간격 22*1.08) * 단락 나누기(엔터) 6회
+                                    .setBackgroundColor(Color.WHITE)
+                                    .setHeight(70f)
+                                    .setFit(Fit.CONTAIN)
+                                    .setAnchor(Anchor.Start, null)
+                            )
+                            .addChild(PDFH1.build("동물 심전도(ECG) 검진 보고서")
+                                    .setFontFromAsset(context, "Pretendard-Bold.ttf")
+                                    .setPadding(0, 0, 0, (int) convertWordPointToPixel(TITLE * SPACING))
+                                    .setBackgroundColor(Color.WHITE)
+                                    .setTextAlign(TextAlign.Start))
+                            .addChild(PDFH2.build("2024.11.27 08:30")
+                                    .setFontFromAsset(context, "Pretendard-Bold.ttf")
+                                    .setPadding(0, 0, 0, (int) convertWordPointToPixel(SUB_TITLE * SPACING)))
+                            .addChild(PDFH2.build("정기 심전도 검사")
+                                    .setFontFromAsset(context, "Pretendard-Bold.ttf")
+                                    .setPadding(0, 0, 0, (int) convertWordPointToPixel(SUB_TITLE * SPACING)))
+                    )
+                    .addChild(PDFEmpty.build()
+                            .setPadding(0, (int) convertWordPointToPixel(10 * (1 + SPACING)), 0, 0) )
+                    .addChild(PDFEmpty.build()
+                            .setPadding(0, (int) convertWordPointToPixel(10 * (1 + SPACING)), 0, 0) );
+        }
+        builder.draw();
+        builder.save(context, StandardDirectory.DIRECTORY_DOWNLOADS, "test_report.pdf");
+    }
+    private float mm2px(float mm){return mm * 2.8348472f;}
+    private float convertWordPointToPixel(float wordPoint){
+        return mm2px(wordPoint * 0.35f);
     }
 }

--- a/android-pdf-writer/src/androidTest/java/com/hangyeolee/androidpdfwriter/PDFTableTest.java
+++ b/android-pdf-writer/src/androidTest/java/com/hangyeolee/androidpdfwriter/PDFTableTest.java
@@ -10,14 +10,19 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 
+import com.hangyeolee.androidpdfwriter.components.PDFEmpty;
 import com.hangyeolee.androidpdfwriter.components.PDFGridCell;
 import com.hangyeolee.androidpdfwriter.components.PDFGridLayout;
 import com.hangyeolee.androidpdfwriter.components.PDFH1;
+import com.hangyeolee.androidpdfwriter.components.PDFH2;
 import com.hangyeolee.androidpdfwriter.components.PDFH3;
 import com.hangyeolee.androidpdfwriter.components.PDFH4;
+import com.hangyeolee.androidpdfwriter.components.PDFH5;
+import com.hangyeolee.androidpdfwriter.components.PDFH6;
 import com.hangyeolee.androidpdfwriter.components.PDFImage;
 import com.hangyeolee.androidpdfwriter.components.PDFLinearLayout;
 import com.hangyeolee.androidpdfwriter.font.PDFFont;
+import com.hangyeolee.androidpdfwriter.utils.Anchor;
 import com.hangyeolee.androidpdfwriter.utils.Fit;
 import com.hangyeolee.androidpdfwriter.utils.Orientation;
 import com.hangyeolee.androidpdfwriter.utils.Paper;
@@ -47,7 +52,7 @@ public class PDFTableTest {
      */
     @Before
     public void setUp() {
-        PDFBuilder.DEBUG = false;
+        PDFBuilder.DEBUG = true;
         context = InstrumentationRegistry.getInstrumentation().getTargetContext();
     }
 
@@ -295,13 +300,20 @@ public class PDFTableTest {
     final float SPACING = 1.08f;            //줄간격 = 폰트 사이즈 *1.08 => 워드 설정값.
     @Test
     public void testReport() {
+        PDFH1.fontSize = convertWordPointToPixel(TITLE);
+        PDFH2.fontSize = convertWordPointToPixel(SUB_TITLE);
+        PDFH3.fontSize = convertWordPointToPixel(SUBJECT);
+        PDFH4.fontSize = convertWordPointToPixel(ANIMAL_INFORMATION);
+        PDFH5.fontSize = convertWordPointToPixel(CONTENTS);
+        PDFH6.fontSize = convertWordPointToPixel(TABLE_CHART);
+
         PDFBuilder builder = new PDFBuilder(Paper.A4).setPagePadding(36, 36).setQuality(70);
         {
             builder.root = PDFLinearLayout.build(Orientation.Vertical)
                     .addChild(PDFEmpty.build()
                             .setPadding(0, (int) convertWordPointToPixel(22 * (1 + SPACING) * 6), 0, 0) )
                     .addChild(PDFLinearLayout.build(Orientation.Vertical)
-                            .addChild(PDFImage.fromResource(context, com.hangyeolee.pdf.core.test.R.drawable.test)     //(폰트사이즈 22 + 줄간격 22*1.08) * 단락 나누기(엔터) 6회
+                            .addChild(PDFImage.fromResource(context, com.hangyeolee.androidpdfwriter.test.R.drawable.test)     //(폰트사이즈 22 + 줄간격 22*1.08) * 단락 나누기(엔터) 6회
                                     .setBackgroundColor(Color.WHITE)
                                     .setHeight(70f)
                                     .setFit(Fit.CONTAIN)
@@ -310,7 +322,6 @@ public class PDFTableTest {
                             .addChild(PDFH1.build("동물 심전도(ECG) 검진 보고서")
                                     .setFontFromAsset(context, "Pretendard-Bold.ttf")
                                     .setPadding(0, 0, 0, (int) convertWordPointToPixel(TITLE * SPACING))
-                                    .setBackgroundColor(Color.WHITE)
                                     .setTextAlign(TextAlign.Start))
                             .addChild(PDFH2.build("2024.11.27 08:30")
                                     .setFontFromAsset(context, "Pretendard-Bold.ttf")

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/PDFBuilder.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/PDFBuilder.java
@@ -40,6 +40,7 @@ public class PDFBuilder {
     public PDFLayout root = null;
 
     public PDFBuilder(Paper pageSize){
+        Zoomable.clear();
         this.pageSize = pageSize;
         Zoomable.getInstance().setPageRect(
                 new RectF(0, 0, pageSize.getWidth(), pageSize.getHeight())
@@ -50,6 +51,7 @@ public class PDFBuilder {
             @FloatRange(from = 1.0f) float width,
             @FloatRange(from = 1.0f) float height,
             PaperUnit unit){
+        Zoomable.clear();
         if(width < 1) width = 1;
         if(height < 1) height = 1;
         this.pageSize.setCustom(width, height, unit);

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/binary/BinaryFont.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/binary/BinaryFont.java
@@ -76,9 +76,11 @@ class BinaryFont extends BinaryDictionary {
         dictionary.put("/CIDSystemInfo",
                 "<< /Registry(Adobe)/Ordering(Identity)/Supplement 0>>");
 
-        // Style 정보 반영
-        if ((macStyle & 0x01) != 0) {  // Bold
-            dictionary.put("/Style", "<< /Panose <000002000000000000000000> >>");
+        if(macStyle != null) {
+            // Style 정보 반영
+            if ((macStyle & 0x01) != 0) {  // Bold
+                dictionary.put("/Style", "<< /Panose <000002000000000000000000> >>");
+            }
         }
 
         dictionary.put("/CIDToGIDMap", "/Identity");

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/binary/BinaryFont.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/binary/BinaryFont.java
@@ -71,6 +71,19 @@ class BinaryFont extends BinaryDictionary {
         }
     }
 
+    public void setCIDSystemInfo(Integer macStyle) {
+        // CIDSystemInfo 딕셔너리
+        dictionary.put("/CIDSystemInfo",
+                "<< /Registry(Adobe)/Ordering(Identity)/Supplement 0>>");
+
+        // Style 정보 반영
+        if ((macStyle & 0x01) != 0) {  // Bold
+            dictionary.put("/Style", "<< /Panose <000002000000000000000000> >>");
+        }
+
+        dictionary.put("/CIDToGIDMap", "/Identity");
+    }
+
     @Override
     public String toDictionaryString() {
         if(!descendantFonts.isEmpty()) {

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/binary/BinarySerializer.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/binary/BinarySerializer.java
@@ -156,6 +156,10 @@ public class BinarySerializer {
             fontDesc.setFontName(info.postScriptName);
             font.setFontDescriptor(fontDesc);
         }else {
+            // Font Subsetting
+            TTFSubsetter subsetter = new TTFSubsetter(info);
+            Integer macStyle = ((TTFSubsetter.HeadTableEntry)subsetter.findTable("head")).getMacStyle();
+
             String CIDName = "CIDFont+"+fontId; //info.postScriptName+"+"+fontId;
             // Font 객체 생성
             font = manager.createObject(n -> new BinaryFont(n, "Identity-H"));
@@ -166,9 +170,7 @@ public class BinarySerializer {
             BinaryFont cidFont = manager.createObject(n -> new BinaryFont(n, null));
             cidFont.setSubtype("CIDFontType2");
             cidFont.setBaseFont(CIDName);//info.postScriptName); // +"+fontId"
-            cidFont.dictionary.put("/CIDSystemInfo", "<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>");
-//            cidFont.dictionary.put("/CMapName", "/Identity-H");
-            cidFont.dictionary.put("/CIDToGIDMap", "/Identity");
+            cidFont.setCIDSystemInfo(macStyle);
             font.addDescendantFont(cidFont);
 
             // FontDescriptor 객체 생성
@@ -178,10 +180,9 @@ public class BinarySerializer {
 
             // Font 파일 생성
             BinaryContentStream fontfile2 = manager.createObject(n -> {
-                // Font Subsetting
-                TTFSubsetter subsetter = new TTFSubsetter(info);
                 return new BinaryContentStream(n, subsetter.subset(), true);
             });
+
             font.setCAMP(createToUnicode(info.usedGlyph));
             cidFont.setW(info.W, info.usedGlyph);
             fontfile2.setSubtype("TrueType"); // Type1C를 TrueType으로 변경

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/binary/BinarySerializer.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/binary/BinarySerializer.java
@@ -158,7 +158,6 @@ public class BinarySerializer {
         }else {
             // Font Subsetting
             TTFSubsetter subsetter = new TTFSubsetter(info);
-            Integer macStyle = ((TTFSubsetter.HeadTableEntry)subsetter.findTable("head")).getMacStyle();
 
             String CIDName = "CIDFont+"+fontId; //info.postScriptName+"+"+fontId;
             // Font 객체 생성
@@ -170,7 +169,6 @@ public class BinarySerializer {
             BinaryFont cidFont = manager.createObject(n -> new BinaryFont(n, null));
             cidFont.setSubtype("CIDFontType2");
             cidFont.setBaseFont(CIDName);//info.postScriptName); // +"+fontId"
-            cidFont.setCIDSystemInfo(macStyle);
             font.addDescendantFont(cidFont);
 
             // FontDescriptor 객체 생성
@@ -183,6 +181,12 @@ public class BinarySerializer {
                 return new BinaryContentStream(n, subsetter.subset(), true);
             });
 
+            Integer macStyle = null;
+            TTFSubsetter.HeadTableEntry head = (TTFSubsetter.HeadTableEntry)subsetter.findTable("head");
+            if(head != null) {
+                macStyle = head.getMacStyle();
+            }
+            cidFont.setCIDSystemInfo(macStyle);
             font.setCAMP(createToUnicode(info.usedGlyph));
             cidFont.setW(info.W, info.usedGlyph);
             fontfile2.setSubtype("TrueType"); // Type1C를 TrueType으로 변경

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/BitmapExtractor.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/BitmapExtractor.java
@@ -93,8 +93,8 @@ public class BitmapExtractor {
                     int height = drawable.getIntrinsicHeight();
 
                     // 크기가 정의되지 않은 경우 기본값 설정
-                    if (width <= 99) width = 100;
-                    if (height <= 99) height = 100;
+                    if (width < 128) width = 128;
+                    if (height < 128) height = 128;
 
                     origin = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
                     Canvas canvas = new Canvas(origin);

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/BitmapExtractor.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/BitmapExtractor.java
@@ -93,8 +93,8 @@ public class BitmapExtractor {
                     int height = drawable.getIntrinsicHeight();
 
                     // 크기가 정의되지 않은 경우 기본값 설정
-                    if (width < 128) width = 128;
-                    if (height < 128) height = 128;
+                    if (width < 512) width = 512;
+                    if (height < 512) height = 512;
 
                     origin = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
                     Canvas canvas = new Canvas(origin);

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/BitmapExtractor.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/BitmapExtractor.java
@@ -4,6 +4,9 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -76,6 +79,30 @@ public class BitmapExtractor {
 
         // 1. Bitmap 생성
         Bitmap origin = BitmapFactory.decodeResource(context.getResources(), resourceId);
+
+        // BitmapFactory가 실패한 경우 (XML drawable 등)
+        if (origin == null) {
+            Drawable drawable = context.getResources().getDrawable(resourceId);
+            if (drawable != null) {
+                // 이미 BitmapDrawable인 경우
+                if (drawable instanceof BitmapDrawable) {
+                    origin = ((BitmapDrawable) drawable).getBitmap();
+                } else {
+                    // 다른 종류의 Drawable인 경우 Bitmap으로 변환
+                    int width = drawable.getIntrinsicWidth();
+                    int height = drawable.getIntrinsicHeight();
+
+                    // 크기가 정의되지 않은 경우 기본값 설정
+                    if (width <= 99) width = 100;
+                    if (height <= 99) height = 100;
+
+                    origin = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+                    Canvas canvas = new Canvas(origin);
+                    drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+                    drawable.draw(canvas);
+                }
+            }
+        }
 
         // 2. 결과 캐싱
         BitmapInfo info = new BitmapInfo(origin);

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFComponent.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFComponent.java
@@ -76,8 +76,11 @@ public abstract class PDFComponent{
         if(width < 0) {
             width = 0;
         }
-        if(height < 0) {
-            height = 0;
+        if(height <= 0) {
+            height = (border.size.top + border.size.bottom
+                    + padding.top + padding.bottom
+                    + margin.top + margin.bottom);
+            updateHeight(height);
         }
 
         relativeX = x;

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFComponent.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFComponent.java
@@ -103,11 +103,11 @@ public abstract class PDFComponent{
         else{
             // 하위 구성 요소인 경우
             // 부모의 사용 가능한 최대 크기 계산
-            float maxW = parent.measureWidth
+            float maxW = parent.measureWidth - relativeX
                     - parent.border.size.left - parent.border.size.right
                     - parent.padding.left - parent.padding.right
                     - left - right;
-            float maxH = parent.measureHeight
+            float maxH = parent.measureHeight - relativeY
                     - parent.border.size.top - parent.border.size.bottom
                     - parent.padding.top - parent.padding.bottom
                     - top - bottom;
@@ -115,11 +115,11 @@ public abstract class PDFComponent{
             if(maxH < 0) maxH = 0;
 
             // 설정된 크기와 최대 크기 중 적절한 값 선택
-            if(0 < width && width + relativeX <= maxW) measureWidth = width;
+            if(0 < width && width <= maxW) measureWidth = width;
                 // 설정한 Width 나 Height 가 최대값을 넘으면, 최대 값으로 Width 나 Height를 설정
-            else measureWidth =  (maxW - relativeX);
-            if(0 < height && height + relativeY <= maxH) measureHeight = height;
-            else measureHeight =  (maxH - relativeY);
+            else measureWidth =  maxW;
+            if(0 < height && height <= maxH) measureHeight = height;
+            else measureHeight =  maxH;
 
             gapX = maxW - measureWidth;
             gapY = maxH - measureHeight;
@@ -266,13 +266,13 @@ public abstract class PDFComponent{
             parent.updateHeight(heightGap);
 
             // 부모의 새로운 크기에 맞춰 자신의 크기 재조정
-            float maxHeight = parent.measureHeight
+            float maxHeight = parent.measureHeight - relativeY
                     - parent.border.size.top - parent.border.size.bottom
                     - parent.padding.top - parent.padding.bottom
                     - verticalMargins;
 
-            if(0 < height && height + relativeY <= maxHeight) measureHeight = height;
-            else measureHeight = maxHeight - relativeY;
+            if(0 < height && height <= maxHeight) measureHeight = height;
+            else measureHeight = maxHeight;
         }
     }
 

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFEmpty.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFEmpty.java
@@ -6,11 +6,6 @@ public class PDFEmpty extends PDFComponent{
     public static PDFEmpty build(){return new PDFEmpty();}
 
     @Override
-    public void measure(float x, float y) {
-        super.measure(x, y);
-    }
-
-    @Override
     public void draw(BinarySerializer serializer) {
         // draw nothing
     }

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFEmpty.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFEmpty.java
@@ -7,7 +7,7 @@ public class PDFEmpty extends PDFComponent{
 
     @Override
     public void measure(float x, float y) {
-        // measure nothing
+        super.measure(x, y);
     }
 
     @Override

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFImage.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFImage.java
@@ -1,7 +1,9 @@
 package com.hangyeolee.androidpdfwriter.components;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.RectF;
@@ -25,6 +27,15 @@ import com.hangyeolee.androidpdfwriter.utils.Zoomable;
 
 import java.util.Locale;
 
+/**
+ * 이미지 컴포넌트.<br>
+ * 모든 이미지는 {@link Bitmap}에서 {@link android.graphics.Bitmap.CompressFormat#JPEG}로 압축되며
+ * 컴포넌트의 크기가 이미지의 크기보다 5배 이상 작다면 압축을 시도 합니다.<br>
+ * Image components.<br>
+ * All images are compressed from {@link Bitmap} to {@link android.graphics.Bitmap.CompressFormat#JPEG}
+ * If the component is more than 5 times smaller than the size of the image, try compressing.<br>
+ * @see PDFText
+ */
 public class  PDFImage extends PDFResourceComponent{
     BitmapExtractor.BitmapInfo info = null;
 
@@ -437,21 +448,70 @@ public class  PDFImage extends PDFResourceComponent{
         super.finalize();
     }
 
+    /**
+     * {@link Context#getAssets()}을 통해 {@link PDFImage}를 만듭니다.<br/>
+     * Create an {@link PDFImage} via {@link Context#getAssets()}.
+     * @see PDFImage#fromFile(String)
+     * @see PDFImage#fromResource(Context, int)
+     * @param context AppContext
+     * @param assetPath 에셋 주소
+     */
     public static PDFImage fromAsset(@NonNull Context context, @NonNull String assetPath){
         return new PDFImage(BitmapExtractor.loadFromAsset(context, assetPath));
     }
+    /**
+     * {@link BitmapFactory#decodeFile(String)}을 통해 {@link PDFImage}를 만듭니다.<br/>
+     * Create an {@link PDFImage} via {@link BitmapFactory#decodeFile(String)}.
+     * @see PDFImage#fromAsset(Context, String)
+     * @see PDFImage#fromResource(Context, int)
+     * @param path 파일 주소
+     */
     public static PDFImage fromFile(@NonNull String path){
         return new PDFImage(BitmapExtractor.loadFromFile(path));
     }
+    /**
+     * {@link BitmapFactory#decodeResource(Resources, int)}을 통해 {@link PDFImage}를 만듭니다.<br/>
+     * Create an {@link PDFImage} via {@link BitmapFactory#decodeResource(Resources, int)}.
+     * @see PDFImage#fromAsset(Context, String)
+     * @see PDFImage#fromFile(String)
+     * @param context AppContext
+     * @param resourceId 리소스 아이디
+     */
     public static PDFImage fromResource(@NonNull Context context, @RawRes int resourceId){
         return new PDFImage(BitmapExtractor.loadFromResource(context, resourceId));
     }
+    /**
+     * {@link Context#getAssets()}을 통해 {@link PDFImage}를 만듭니다.<br/>
+     * Create an {@link PDFImage} via {@link Context#getAssets()}.
+     * @see PDFImage#fromFile(String, int) 
+     * @see PDFImage#fromResource(Context, int, int)
+     * @param context AppContext
+     * @param assetPath 에셋 주소
+     * @param fit 이미지 맞춤
+     */
     public static PDFImage fromAsset(@NonNull Context context, @NonNull String assetPath, @Fit.FitInt int fit){
         return new PDFImage(BitmapExtractor.loadFromAsset(context, assetPath), fit);
     }
+    /**
+     * {@link BitmapFactory#decodeFile(String)}을 통해 {@link PDFImage}를 만듭니다.<br/>
+     * Create an {@link PDFImage} via {@link BitmapFactory#decodeFile(String)}.
+     * @see PDFImage#fromAsset(Context, String, int)
+     * @see PDFImage#fromResource(Context, int, int)
+     * @param path 파일 주소
+     * @param fit 이미지 맞춤
+     */
     public static PDFImage fromFile(@NonNull String path, @Fit.FitInt int fit){
         return new PDFImage(BitmapExtractor.loadFromFile(path), fit);
     }
+    /**
+     * {@link BitmapFactory#decodeResource(Resources, int)}을 통해 {@link PDFImage}를 만듭니다.<br/>
+     * Create an {@link PDFImage} via {@link BitmapFactory#decodeResource(Resources, int)}.
+     * @see PDFImage#fromAsset(Context, String, int)
+     * @see PDFImage#fromFile(String, int)
+     * @param context AppContext
+     * @param resourceId 리소스 아이디
+     * @param fit 이미지 맞춤
+     */
     public static PDFImage fromResource(@NonNull Context context, @RawRes int resourceId, @Fit.FitInt int fit){
         return new PDFImage(BitmapExtractor.loadFromResource(context, resourceId), fit);
     }
@@ -459,7 +519,7 @@ public class  PDFImage extends PDFResourceComponent{
     /**
      * {@link Bitmap}을 통해서 {@link PDFImage} 를 생성합니다.<br>
      * {@link Bitmap}으로 키값을 생성하는 데, 시간이 오래 걸릴 수 있습니다.<br>
-     * Create PDFimage via {@link Bitmap}.<br>
+     * Create {@link PDFImage} via {@link Bitmap}.<br>
      * Generating a key value with {@link Bitmap} can take a long time.<br>
      * @deprecated 추후 업데이트에서 삭제될 예정입니다.<br>It will be removed from future updates.
      * @see PDFImage#fromAsset(Context, String)
@@ -476,7 +536,7 @@ public class  PDFImage extends PDFResourceComponent{
     /**
      * {@link Bitmap}을 통해서 {@link PDFImage} 를 생성합니다.<br>
      * {@link Bitmap}으로 키값을 생성하는 데, 시간이 오래 걸릴 수 있습니다.<br>
-     * Create PDFimage via {@link Bitmap}.<br>
+     * Create {@link PDFImage} via {@link Bitmap}.<br>
      * Generating a key value with {@link Bitmap} can take a long time.<br>
      * @deprecated 추후 업데이트에서 삭제될 예정입니다.<br>It will be removed from future updates.
      * @see PDFImage#fromAsset(Context, String, int)

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFImage.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFImage.java
@@ -477,7 +477,9 @@ public class  PDFImage extends PDFResourceComponent{
      * @see PDFImage#fromAsset(Context, String)
      * @see PDFImage#fromFile(String)
      * @param context AppContext
-     * @param resourceId 리소스 아이디
+     * @param resourceId 리소스 아이디<br>
+     *                   xml drawable은 v1.1.1에서 지원하지 않습니다.<br>
+     *                   xml drawable is not supported in v1.1.1.
      */
     public static PDFImage fromResource(@NonNull Context context, @RawRes int resourceId){
         return new PDFImage(BitmapExtractor.loadFromResource(context, resourceId));
@@ -511,7 +513,9 @@ public class  PDFImage extends PDFResourceComponent{
      * @see PDFImage#fromAsset(Context, String, int)
      * @see PDFImage#fromFile(String, int)
      * @param context AppContext
-     * @param resourceId 리소스 아이디
+     * @param resourceId 리소스 아이디<br>
+     *                   xml drawable은 v1.1.1에서 지원하지 않습니다.<br>
+     *                   xml drawable is not supported in v1.1.1.
      * @param fit 이미지 맞춤
      */
     public static PDFImage fromResource(@NonNull Context context, @RawRes int resourceId, @Fit.FitInt int fit){

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFImage.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFImage.java
@@ -297,6 +297,8 @@ public class  PDFImage extends PDFResourceComponent{
                     }
                 }
             }
+        }else{
+            info.resize = info.origin;
         }
     }
 

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFLinearLayout.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFLinearLayout.java
@@ -70,57 +70,18 @@ public class PDFLinearLayout extends PDFLayout {
                 child.setSize(null, childHeight);
             }
 
-            // PDFLayout은 페이지네이션 체크 건너뛰기
-            if (child instanceof PDFImage){
-                int stack = 0;
-                for (; ; ) {
-                    // 하위 구성 요소 위치 측정
-                    child.measure(0, currentY);
-                    float maxW = measureWidth
-                            - border.size.left - border.size.right
-                            - padding.left - padding.right
-                            - child.margin.left - child.margin.right;
-                    float maxH = measureHeight - currentY
-                            - border.size.top - border.size.bottom
-                            - padding.top - padding.bottom
-                            - child.margin.top - child.margin.bottom;
-                    childReanchor(child, maxW, maxH);
-
-                    // 페이지 경계 확인 및 조정
-                    int currentPage = calculatePageIndex(child.measureY);
-                    int endPage = calculatePageIndex(child.measureY, child.getTotalHeight());
-
-                    if (currentPage != endPage) {
-                        stack++;
-                        if (stack > 2) {
-                            // 스택 오버 플로우 체크
-                            // 페이지 경계를 두 번 이상 넘어서게 되면
-                            // 하위 구성 요소가 페이지보다 크기가 크다고 판단.
-                            throw new StackOverflowError("Height of child component Too Large");
-                        }
-
-                        // 다음 페이지 시작점으로 이동
-                        float newY = (endPage) * contentHeight;
-                        // 변경된 위치로 다시 해당 컴포넌트 재 연산
-                        currentY = pageEdgeCheck(child, newY, child.measureY);
-                    } else {
-                        break;
-                    }
-                }
-            } else {
-                // 하위 구성 요소 위치 측정
-                child.measure(0, currentY);
-                if (!(child instanceof PDFLayout)) {
-                    float maxW = measureWidth
-                            - border.size.left - border.size.right
-                            - padding.left - padding.right
-                            - child.margin.left - child.margin.right;
-                    float maxH = measureHeight - currentY
-                            - border.size.top - border.size.bottom
-                            - padding.top - padding.bottom
-                            - child.margin.top - child.margin.bottom;
-                    childReanchor(child, maxW, maxH);
-                }
+            // 하위 구성 요소 위치 측정
+            child.measure(0, currentY);
+            if (!(child instanceof PDFLayout)) {
+                float maxW = measureWidth
+                        - border.size.left - border.size.right
+                        - padding.left - padding.right
+                        - child.margin.left - child.margin.right;
+                float maxH = measureHeight - currentY
+                        - border.size.top - border.size.bottom
+                        - padding.top - padding.bottom
+                        - child.margin.top - child.margin.bottom;
+                childReanchor(child, maxW, maxH);
             }
 
             // 다음 컴포넌트 위치 계산
@@ -156,52 +117,16 @@ public class PDFLinearLayout extends PDFLayout {
                     fitChildrenToLayout ? measureHeight : null
             );
 
-            if (child instanceof PDFImage){
-                int stack = 0;
-                float currentY = 0;
-                for (; ; ) {
-                    // 하위 구성 요소 위치 측정
-                    child.measure(currentX, currentY);
-                    float maxW = cellWidth - child.margin.left - child.margin.right;
-                    float maxH = measureHeight
-                            - border.size.top - border.size.bottom
-                            - padding.top - padding.bottom
-                            - child.margin.top - child.margin.bottom;
-                    childReanchor(child, maxW, maxH);
-
-                    // 페이지 경계 확인 및 조정
-                    int currentPage = calculatePageIndex(child.measureY);
-                    int endPage = calculatePageIndex(child.measureY, child.getTotalHeight());
-
-                    if (currentPage != endPage) {
-                        stack++;
-                        if (stack > 2) {
-                            // 스택 오버 플로우 체크
-                            // 페이지 경계를 두 번 이상 넘어서게 되면
-                            // 하위 구성 요소가 페이지보다 크기가 크다고 판단.
-                            throw new StackOverflowError("Height of child component Too Large");
-                        }
-
-                        // 다음 페이지 시작점으로 이동
-                        float newY = (endPage) * contentHeight;
-                        // 변경된 위치로 다시 해당 컴포넌트 재 연산
-                        currentY = pageEdgeCheck(child, newY, child.measureY);
-                    } else {
-                        break;
-                    }
-                }
-            }else {
-                // 하위 구성 요소 위치 측정
-                child.measure(currentX, 0);
-                // PDFLayout은 페이지네이션 체크 건너뛰기
-                if (!(child instanceof PDFLayout)) {
-                    float maxW = cellWidth - child.margin.left - child.margin.right;
-                    float maxH = measureHeight
-                            - border.size.top - border.size.bottom
-                            - padding.top - padding.bottom
-                            - child.margin.top - child.margin.bottom;
-                    childReanchor(child, maxW, maxH);
-                }
+            // 하위 구성 요소 위치 측정
+            child.measure(currentX, 0);
+            // PDFLayout은 페이지네이션 체크 건너뛰기
+            if (!(child instanceof PDFLayout)) {
+                float maxW = cellWidth - child.margin.left - child.margin.right;
+                float maxH = measureHeight
+                        - border.size.top - border.size.bottom
+                        - padding.top - padding.bottom
+                        - child.margin.top - child.margin.bottom;
+                childReanchor(child, maxW, maxH);
             }
 
             maxHeight = Math.max(maxHeight, child.getTotalHeight());

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFPageBreak.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFPageBreak.java
@@ -1,8 +1,8 @@
 package com.hangyeolee.androidpdfwriter.components;
 
 
-import com.hangyeolee.pdf.core.binary.BinarySerializer;
-import com.hangyeolee.pdf.core.utils.Zoomable;
+import com.hangyeolee.androidpdfwriter.binary.BinarySerializer;
+import com.hangyeolee.androidpdfwriter.utils.Zoomable;
 
 /**
  * 강제 페이지 나누기를 위한 컴포넌트.<br>

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFPageBreak.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFPageBreak.java
@@ -1,7 +1,13 @@
 package com.hangyeolee.androidpdfwriter.components;
 
 
+import android.graphics.RectF;
+
+import androidx.annotation.ColorInt;
+
 import com.hangyeolee.androidpdfwriter.binary.BinarySerializer;
+import com.hangyeolee.androidpdfwriter.listener.Action;
+import com.hangyeolee.androidpdfwriter.utils.Border;
 import com.hangyeolee.androidpdfwriter.utils.Zoomable;
 
 /**
@@ -20,24 +26,133 @@ public class PDFPageBreak extends PDFComponent {
         // 현재 페이지의 남은 공간을 모두 차지하도록 높이 조정
         float pageHeight = Zoomable.getInstance().getContentHeight();
         int currentPage = calculatePageIndex(measureY);
-        float nextPageY = (currentPage + 1) * pageHeight;
+        float nextHeight = (currentPage + 1) * pageHeight;
+        float remainingHeight = nextHeight - measureY;
 
-        // 다음 페이지 시작점까지의 거리를 높이로 설정
-        float remainingHeight = nextPageY - measureY;
         height = remainingHeight;
-        float _height = getTotalHeight();
         // 부모 컴포넌트의 높이도 업데이트
-        while (remainingHeight > _height) {
-            updateHeight(remainingHeight - _height);
-            _height = getTotalHeight();
+        if (remainingHeight > measureHeight) {
+            updateHeight(remainingHeight - measureHeight);
         }
     }
 
     @Override
     public void draw(BinarySerializer serializer) {
+        super.draw(serializer);
         // draw nothing
     }
 
+    /**
+     * 페이지 나누기 컴포넌트는 자체적으로 Margin을 가질 수 없다.<br>
+     * Cells cannot have Margin on their own.
+     */
+    @Override
+    @Deprecated
+    public PDFPageBreak setMargin(RectF margin) {
+        return this;
+    }
+
+    /**
+     * 페이지 나누기 컴포넌트는 자체적으로 Margin을 가질 수 없다.<br>
+     * Cells cannot have Margin on their own.
+     */
+    @Override
+    @Deprecated
+    public PDFPageBreak setMargin(float left, float top, float right, float bottom) {
+        return this;
+    }
+
+    /**
+     * 페이지 나누기 컴포넌트는 자체적으로 Margin을 가질 수 없다.<br>
+     * Cells cannot have Margin on their own.
+     */
+    @Override
+    @Deprecated
+    public PDFPageBreak setMargin(float all) {
+        return this;
+    }
+
+    /**
+     * 페이지 나누기 컴포넌트는 자체적으로 Margin을 가질 수 없다.<br>
+     * Cells cannot have Margin on their own.
+     */
+    @Override
+    @Deprecated
+    public PDFPageBreak setMargin(float horizontal, float vertical) {
+        return this;
+    }
+
+    /**
+     * 페이지 나누기 컴포넌트는 자체적으로 Padding 을 가질 수 없다.<br>
+     * Cells cannot have Padding on their own.
+     */
+    @Override
+    @Deprecated
+    public PDFPageBreak setPadding(float all) {
+        return this;
+    }
+
+    /**
+     * 페이지 나누기 컴포넌트는 자체적으로 Padding 을 가질 수 없다.<br>
+     * Cells cannot have Padding on their own.
+     */
+    @Override
+    @Deprecated
+    public PDFPageBreak setPadding(float horizontal, float vertical) {
+        return this;
+    }
+
+    /**
+     * 페이지 나누기 컴포넌트는 자체적으로 Padding 을 가질 수 없다.<br>
+     * Cells cannot have Padding on their own.
+     */
+    @Override
+    @Deprecated
+    public PDFPageBreak setPadding(RectF padding) {
+        return this;
+    }
+
+    /**
+     * 페이지 나누기 컴포넌트는 자체적으로 Padding 을 가질 수 없다.<br>
+     * Cells cannot have Padding on their own.
+     */
+    @Override
+    @Deprecated
+    public PDFPageBreak setPadding(float left, float top, float right, float bottom) {
+        return this;
+    }
+
+    /**
+     * 페이지 나누기 컴포넌트는 자체적으로 Border을 가질 수 없다.<br>
+     * Cells cannot have Border on their own.
+     */
+    @Override
+    @Deprecated
+    public PDFPageBreak setBorder(Action<Border, Border> action) {
+        return this;
+    }
+
+    /**
+     * 페이지 나누기 컴포넌트는 자체적으로 Border을 가질 수 없다.<br>
+     * Cells cannot have Border on their own.
+     */
+    @Override
+    @Deprecated
+    public PDFPageBreak setBorder(float size, @ColorInt int color) {
+        return this;
+    }
+
+    /**
+     * 페이지 나누기 컴포넌트는 자체적으로 Anchor을 가질 수 없다.<br>
+     * Cells cannot have Anchor on their own.
+     */
+    @Override
+    @Deprecated
+    public PDFPageBreak setAnchor(Integer horizontal, Integer vertical) {
+        super.setAnchor(horizontal, vertical);
+        return this;
+    }
+    
     /**
      * {@link PDFPageBreak}를 생성합니다.
      * @return 새로운 PDFPageBreak 인스턴스

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFPageBreak.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFPageBreak.java
@@ -1,0 +1,46 @@
+package com.hangyeolee.androidpdfwriter.components;
+
+
+import com.hangyeolee.pdf.core.binary.BinarySerializer;
+import com.hangyeolee.pdf.core.utils.Zoomable;
+
+/**
+ * 강제 페이지 나누기를 위한 컴포넌트.<br>
+ * 이 컴포넌트 이후의 모든 내용은 새로운 페이지에서 시작됩니다.<br>
+ * Components for forced page splitting.<br>
+ * Everything after this component begins on a new page.<br>
+ */
+public class PDFPageBreak extends PDFComponent {
+    public PDFPageBreak() {super();}
+
+    @Override
+    public void measure(float x, float y) {
+        super.measure(x, y);
+
+        // 현재 페이지의 남은 공간을 모두 차지하도록 높이 조정
+        float pageHeight = Zoomable.getInstance().getContentHeight();
+        int currentPage = calculatePageIndex(measureY);
+        float nextPageY = (currentPage + 1) * pageHeight;
+
+        // 다음 페이지 시작점까지의 거리를 높이로 설정
+        float remainingHeight = nextPageY - measureY;
+        height = remainingHeight;
+        float _height = getTotalHeight();
+        // 부모 컴포넌트의 높이도 업데이트
+        while (remainingHeight > _height) {
+            updateHeight(remainingHeight - _height);
+            _height = getTotalHeight();
+        }
+    }
+
+    @Override
+    public void draw(BinarySerializer serializer) {
+        // draw nothing
+    }
+
+    /**
+     * {@link PDFPageBreak}를 생성합니다.
+     * @return 새로운 PDFPageBreak 인스턴스
+     */
+    public static PDFPageBreak build() { return new PDFPageBreak(); }
+}

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFText.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFText.java
@@ -79,6 +79,21 @@ public class PDFText extends PDFResourceComponent {
     public void measure(float x, float y) {
         super.measure(x, y);
         if(text != null) {
+            boolean isBase14 = BinaryConverter.isBase14Font(info.postScriptName);
+            if(!isBase14){
+                // 1000 유닛 기준으로 변환할 스케일 팩터 계산
+                float scale = 1000f / bufferPaint.getTextSize();
+                for(char c : text.toCharArray()) {
+                    float width = bufferPaint.measureText(String.valueOf(c), 0, 1) - 0.5f;
+                    // 글리프
+                    Integer glyphIndex = info.glyphIndexMap.get(c);
+                    if (glyphIndex != null) {
+                        info.W.put(c, (int) Math.ceil(width * scale));
+                        info.usedGlyph.put(c, glyphIndex);
+                    }
+                }
+            }
+
             float maxWidth = 0;
             float _width = (measureWidth - border.size.left - padding.left
                     - border.size.right - padding.right);
@@ -231,17 +246,6 @@ public class PDFText extends PDFResourceComponent {
             paint.getTextBounds(String.valueOf(c), 0, 1, bounds);
             minLeft = Math.min(minLeft, bounds.left);
             maxRight = Math.max(maxRight, bounds.right);
-        }
-        if(!isBase14){
-            for(char c : text.toCharArray()) {
-                float width = paint.measureText(String.valueOf(c), 0, 1) - 0.75f;
-                // 글리프
-                Integer glyphIndex = info.glyphIndexMap.get(c);
-                if (glyphIndex != null) {
-                    info.W.put(c, (int) Math.ceil(width * scale));
-                    info.usedGlyph.put(c, glyphIndex);
-                }
-            }
         }
 
         fontBBox = new Rect(

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFText.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFText.java
@@ -21,6 +21,7 @@ import com.hangyeolee.androidpdfwriter.exceptions.FontNotFoundException;
 import com.hangyeolee.androidpdfwriter.font.FontMetrics;
 import com.hangyeolee.androidpdfwriter.font.PDFFont;
 import com.hangyeolee.androidpdfwriter.utils.Fit;
+import com.hangyeolee.androidpdfwriter.utils.FloatComparison;
 import com.hangyeolee.androidpdfwriter.utils.TextAlign;
 import com.hangyeolee.androidpdfwriter.utils.Border;
 
@@ -153,14 +154,16 @@ public class PDFText extends PDFResourceComponent {
             float updatedHeight = measureTextHeight();
             height = (updatedHeight + border.size.top + padding.top
                     + border.size.bottom + padding.bottom + margin.top + margin.bottom);
-            float _height = getTotalHeight();
+            float availableHeight = measureHeight - border.size.top - padding.top
+                    - border.size.bottom - padding.bottom;
             /*
             updatedHeight 가 measureHeight 보다 크다면?
             상위 컴포넌트의 Height를 업데이트 한다.
             */
-            while (updatedHeight > _height) {
-                updateHeight(updatedHeight - _height);
-                _height = getTotalHeight();
+            while (FloatComparison.isGreater(updatedHeight, availableHeight)) {
+                updateHeight(updatedHeight - availableHeight);
+                availableHeight = measureHeight - border.size.top - padding.top
+                        - border.size.bottom - padding.bottom;
             }
         }
     }

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFText.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/components/PDFText.java
@@ -84,7 +84,7 @@ public class PDFText extends PDFResourceComponent {
                 // 1000 유닛 기준으로 변환할 스케일 팩터 계산
                 float scale = 1000f / bufferPaint.getTextSize();
                 for(char c : text.toCharArray()) {
-                    float width = bufferPaint.measureText(String.valueOf(c), 0, 1) - 0.5f;
+                    float width = bufferPaint.measureText(String.valueOf(c), 0, 1) - 0.75f;
                     // 글리프
                     Integer glyphIndex = info.glyphIndexMap.get(c);
                     if (glyphIndex != null) {
@@ -125,7 +125,7 @@ public class PDFText extends PDFResourceComponent {
                     float w = layout.getLineWidth(i);
                     if (w > maxWidth) maxWidth = w;
                 }
-                if (maxWidth == _width) {
+                if (maxWidth >= _width) {
                     maxWidth += margin.right + margin.left + border.size.right + border.size.left
                             + padding.right + padding.left;
                     break;

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/font/TTFSubsetter.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/font/TTFSubsetter.java
@@ -50,7 +50,7 @@ public class TTFSubsetter {
         private short yMin;                     // FWord: minimum y value
         private short xMax;                     // FWord: maximum x value
         private short yMax;                     // FWord: maximum y value
-        private int macStyle;                   // uint16: mac style bits
+        private Integer macStyle = null;        // uint16: mac style bits
         private int lowestRecPPEM;             // uint16: smallest readable size in pixels
         private short fontDirectionHint;        // int16: font direction hint
         private short indexToLocFormat;         // int16: format of 'loca' table

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/utils/FloatComparison.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/utils/FloatComparison.java
@@ -1,0 +1,30 @@
+package com.hangyeolee.androidpdfwriter.utils;
+
+public class FloatComparison {
+    private static final float EPSILON = 1E-5f; // 적절한 epsilon 값 설정
+
+    // 두 float이 실질적으로 같은지 비교
+    public static boolean isEqual(float a, float b) {
+        return Math.abs(a - b) < EPSILON;
+    }
+
+    // a가 b보다 크거나 같은지 비교
+    public static boolean isGreater(float a, float b) {
+        return a > b && !isEqual(a, b);
+    }
+
+    // a가 b보다 크거나 같은지 비교
+    public static boolean isGreaterOrEqual(float a, float b) {
+        return a > b || isEqual(a, b);
+    }
+
+    // a가 b보다 크거나 같은지 비교
+    public static boolean isLess(float a, float b) {
+        return a < b && !isEqual(a, b);
+    }
+
+    // a가 b보다 작거나 같은지 비교
+    public static boolean isLessOrEqual(float a, float b) {
+        return a < b || isEqual(a, b);
+    }
+}

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/utils/FloatComparison.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/utils/FloatComparison.java
@@ -1,7 +1,7 @@
 package com.hangyeolee.androidpdfwriter.utils;
 
 public class FloatComparison {
-    private static final float EPSILON = 1E-5f; // 적절한 epsilon 값 설정
+    private static final float EPSILON = 1E-4f; // 적절한 epsilon 값 설정 float 값 100~1000 사이에 적합
 
     // 두 float이 실질적으로 같은지 비교
     public static boolean isEqual(float a, float b) {

--- a/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/utils/Zoomable.java
+++ b/android-pdf-writer/src/main/java/com/hangyeolee/androidpdfwriter/utils/Zoomable.java
@@ -15,6 +15,11 @@ public class Zoomable {
     private RectF pageRect = null;
     private final RectF padding = new RectF();
 
+    public static void clear(){
+        getInstance().pageRect = null;
+        getInstance().padding.set(0, 0, 0, 0);
+    }
+
     /**
      * PDF 페이지 크기 설정
      * @param pageRect 크기


### PR DESCRIPTION
# Table of Contents
1. [PDFImage Resource Issue](#pdfimage-resource-issue)
2. [True Type Font glyph Issue](#true-type-font-glyph-issue)
3. [Layout Height Issue](#layout-height-issue)
4. [Korean](#PDFImage-리소스-이슈)

## PDFImage Resource Issue
First of all, all drawable resources were converted into bitmaps.
If the minimum size is not specified for any drawable, it will be converted to a bitmap with 512 pixels and will not support a transparent background.
Similarly, transparent backgrounds in png images are also not supported.

## True Type Font glyph Issue
Sometimes there is a problem that some composite glyphs are not shown properly.
When proceeding with font sub-setting, the reference glyph ID of the composite glyph was changed from the original ID to the sub-set ID.

## Layout Height Issue
We solved the problem of gap when calculating the height of the component in the layout.
When changing the layout height due to Component, we solved the infinite loop issue due to the floating point difference in units below 1E-4.
All page nations have been removed; instead, all components are truncated and represented when they are between pages (especially image components)

## PDFImage 리소스 이슈
일단 모든 drawable 리소스를 비트맵으로 변환하도록 하였습니다.
최소 크기가 지정되어 있지 않다면, 512 픽셀을 가지는 비트맵으로 변환 되며, 투명한 배경은 지원하지 않습니다.
마찬가지로 png 이미지의 투명한 배경 또한 지원되지 않습니다.

## TTF 폰트 글리프 이슈
가끔 몇몇의 복합 글리프가 제대로 보여지지 않는 문제가 있습니다.
폰트 서브 세팅을 진행할 때, 복합 글리프의 참조 글리프 ID 를 원본 ID 에서 서브 세팅 ID 로 변경하였습니다.

## Layout 높이 이슈
Layout 내에서 Component의 높이 계산 시 gap 이 발생하는 문제를 해결 하였습니다.
Component로 인한 Layout 높이 변경 시 1E-4 이하 단위의 부동 소수점 차이로 인한 무한 루프 이슈를 해결하였습니다.
모든 페이지 네이션이 제거되었습니다. 대신 모든 컴포넌트는 페이지 사이에 있을 시 잘려서 표현됩니다. (특히 이미지 컴포넌트)